### PR TITLE
Changed instructions for svn setup in mac

### DIFF
--- a/InstallationMacOsX.rst
+++ b/InstallationMacOsX.rst
@@ -106,10 +106,8 @@ http://www.open.collab.net/downloads/community/]].
 Then add the following lines to config/local_environment_override.rb 
 from the MarkUs root directory (if this file does not exist, create it)::
 
-    Markus::Application.configure do
-        config.autoload_paths << "/opt/subversion/lib/svn-ruby"
-        config.autoload_paths << "/opt/subversion/lib/svn-ruby/universal-darwin/"
-    end
+    config.autoload_paths << "/opt/subversion/lib/svn-ruby"
+    config.autoload_paths << "/opt/subversion/lib/svn-ruby/universal-darwin/"
 
 Setting up Rubygems
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The svn setup had mac users add some extra paths to config.auto_loadpaths, but in order to keep this from getting committed it shouldn't be added to the environment.rb file but instead to the local_environment_override.rb file which is ignored by git.
