### PR TITLE
Added "development" environment default admin credentials for SQLite

### DIFF
--- a/InstallationGnuLinux.rst
+++ b/InstallationGnuLinux.rst
@@ -249,6 +249,8 @@ can do so by::
 
     $> bundle exec rails server  #boots up mongrel (or WebRink, if mongrel is not installed/found)
 
+The default admin user is 'a' with any non-empty password. Look at db/seeds.rb for other users.
+
 If this doesn't work try::
     $> rails s
 

--- a/InstallationMacOsX.rst
+++ b/InstallationMacOsX.rst
@@ -268,6 +268,8 @@ You can learn more about other rake tasks by entering::
 
 You should now be able to access MarkUs at http://localhost:3000 in your browser.
 
+The default admin user is 'a' with any non-empty password. Look at db/seeds.rb for other users.
+
 **Happy Coding!**
 
 .. figure:: images/Installation_MacOsX-MarkUs.png

--- a/InstallationWindows.rst
+++ b/InstallationWindows.rst
@@ -164,6 +164,7 @@ If you have a problem executing the above command then it is likely that there i
     - use the instructor user name that you set up before (for example "markus") and any number of characters > 0 as password
 
  * If you see MarkUs login screen, Congratulations!! Your installation is a success!!
+    - The default admin user is 'a' with any non-empy password. Look at db/seeds.rb for other users.
 
 Optional: Install an Editor
 ================================================================================


### PR DESCRIPTION
I wasn't able to find the credentials listed on the development setup page, might be helpful to have them in an obvious place.
