### PR TITLE
Updated name of default instructor

### DIFF
--- a/Developer-Guide--Set-Up-With-Docker.md
+++ b/Developer-Guide--Set-Up-With-Docker.md
@@ -44,7 +44,7 @@ If you want to get started on working on MarkUs quickly and painlessly, this is 
 
     2. Run the command `rails js:routes`, which will take a moment to generate a required file.
 
-8. Open your web browser and type in the URL `localhost:3000/csc108`. The initial page load might be slow, but eventually you should see a login page. Use the username `a` and any non-empty password to login.
+8. Open your web browser and type in the URL `localhost:3000/csc108`. The initial page load might be slow, but eventually you should see a login page. Use the username `instructor` and any non-empty password to login.
 
     *Tip*: to terminate the Rails server, go to the terminal window where the server is running and press `Ctrl + C`/`⌘ + C`.
 

--- a/Developer-Guide--Set-Up-With-Vagrant.md
+++ b/Developer-Guide--Set-Up-With-Vagrant.md
@@ -25,7 +25,7 @@ Finally, run `markus` from the project directory.
 
 You should now be able to access the site from your host machine's browser at `http://0.0.0.0:3000/csc108`.
 
-The default instructor user is `a` with any non-empty password. Look at `db/seeds.rb` for other users.
+The default instructor user is `instructor` with any non-empty password. Look at `db/seeds.rb` for other users.
 
 If you are using RubyMine then you should jump down to the set up instructions for RubyMine below before proceeding to the next step.
 


### PR DESCRIPTION
This pull request makes a non admin related documentation change from PR [#5897](https://github.com/MarkUsProject/Markus/pull/5897), namely to reflect the fact that the default instructor for development has been renamed from `a` to `instructor`

## Changes
- Changed all references of logging in as an instructor with the username `a` to one with the username `instructor`