### PR TITLE
Update Groups API documentation

### DIFF
--- a/RESTful-API.md
+++ b/RESTful-API.md
@@ -665,11 +665,11 @@ NOTE: This will also send the updated specs to the server running the autotester
     "members": [
       {
         "membership_status": "inviter",
-        "user_id": 9
+        "role_id": 9
       },
       {
         "membership_status": "accepted",
-        "user_id": 24
+        "role_id": 24
       }
     ]
   }
@@ -756,11 +756,11 @@ NOTE: This will also send the updated specs to the server running the autotester
   "members": [
     {
       "membership_status": "inviter",
-      "user_id": 9
+      "role_id": 9
     },
     {
       "membership_status": "accepted",
-      "user_id": 24
+      "role_id": 24
     }
   ]
 }


### PR DESCRIPTION
Updates the Groups documentation to indicate that group show.index return memberships as `role_ids` instead of `user_ids`