### PR TITLE
Add documentation for Capybara Tests

### DIFF
--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -294,11 +294,11 @@ describe Action do
 end
 ```
 
-Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe actions performed via the UI.
+Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe and test actions performed via the UI. These tests use Capybara, an acceptance test framework that simulates user interaction. For more information, documentation about Capybara can be found [here](https://rubydoc.info/github/teamcapybara/capybara/master).
 
 ### Writing System Tests
 
-System tests are written using the Capybara Design Specification Language. These tests revolve around 
+System tests are written using the Capybara Design Specification Language. These tests revolve around finding elements on a given page and performing certain actions on that element; similar to how you would interact with the page as a normal user. Also like a normal user, you can only find and perform actions on elements that can be visibly seen via the UI. For a helpful quick start on learning the Capybara Design Specification Language, see the documentation on the [Capybara DSL](https://github.com/teamcapybara/capybara#the-dsl). [This cheatsheet](https://devhints.io/capybara) is also a helpful guide in learning what basic actions you can perform.
 
 ### Running System Tests
 
@@ -309,14 +309,13 @@ System tests require extra setup steps in order for you to run them locally. As 
 2. Download ChromeDriver. This will allow our System Tests to perform actions on the Chrome browser.
 
 3. In a terminal on your machine, run ChromeDriver by typing the command `chromedriver --whitelisted-ips`. The `--whitelisted-ips` flag is used to let ChromeDriver know to allow the connection with a docker terminal.
-
-    On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
+> :spirl_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
 
 4. In a separate terminal, start a bash shell within the Docker Rails environment by running `docker-compose run -p 3434:3434 --rm rails bash`. Notice that we exposed port 3434 by adding the argument `-p 3434:3434`. Port 3434 is the port with which Capybara will use to serve the test MarkUs instance for Chrome to use.
 
 5. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ rspec spec/system` in the bash shell you created in step 4. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. You will also notice that due to the additional setup, by default system tests are ignored and must be explicitly defined in order for rspec to run them. Simply running `RAILS_RELATIVE_URL_ROOT=/ rspec` will not run the tests.
 
-    **Optional**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can set and add the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
+    **Optional**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can add and set the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
 
 #### Troubleshooting
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -294,7 +294,7 @@ describe Action do
 end
 ```
 
-Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe and test actions performed via the UI. These tests use Capybara, an acceptance test framework that simulates user interaction. For more information, documentation about Capybara can be found [here](https://rubydoc.info/github/teamcapybara/capybara/master).
+Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe and test actions performed via the UI. These tests use Capybara, an acceptance test framework that simulates user interaction. For more information, documentation about Capybara can be found [here](https://rubydoc.info/github/teamcapybara/capybara/master). These simulated user interactions are run and tested on a chrome browser running on your local machine.
 
 ### Writing System Tests
 
@@ -302,11 +302,11 @@ System tests are written using the Capybara Design Specification Language. These
 
 ### Running System Tests
 
-System tests require extra setup steps in order for you to run them locally. As a result, they are disabled by default. If you wish to run and system tests on your machine you will need to perform the following steps:
+System tests require extra setup steps in order for you to run them locally. As a result, they are disabled by default. If you wish to run system tests on your machine you will need to perform the following steps:
 
-1. Download Chrome on your machine. This is the browser with which we will use to test UI actions.
+1. Download [Chrome](https://support.google.com/chrome/answer/95346?hl=en&co=GENIE.Platform%3DDesktop) on your machine. This is the browser with which we will use to test UI actions.
 
-2. Download ChromeDriver. This will allow our System Tests to perform actions on the Chrome browser.
+2. Download [ChromeDriver](https://chromedriver.chromium.org/downloads). This will allow our System Tests to perform actions on the Chrome browser.
 
 3. In a terminal on your machine, run ChromeDriver by typing the command `chromedriver --whitelisted-ips`. The `--whitelisted-ips` flag is used to let ChromeDriver know to allow the connection with a docker terminal.
 
@@ -314,9 +314,9 @@ System tests require extra setup steps in order for you to run them locally. As 
 
 4. In a separate terminal, start a bash shell within the Docker Rails environment by running `docker-compose run -p 3434:3434 --rm rails bash`. Notice that we exposed port 3434 by adding the argument `-p 3434:3434`. Port 3434 is the port with which Capybara will use to serve the test MarkUs instance for Chrome to use.
 
-5. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ rspec spec/system` in the bash shell you created in step 4. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. You will also notice that due to the additional setup, by default system tests are ignored and must be explicitly defined in order for rspec to run them. Simply running `RAILS_RELATIVE_URL_ROOT=/ rspec` will not run the tests.
+5. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ rspec spec/system` in the bash shell you created in step 4. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. You will also notice that due to the additional setup for system tests, they are ignored by default and must be explicitly defined in order for rspec to run them. Simply running `RAILS_RELATIVE_URL_ROOT=/ rspec` will not run the system test suite.
 
-    **Optional**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can add and set the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
+    **Optional**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging), you can set and add the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
 
 #### Troubleshooting
 
@@ -329,7 +329,7 @@ Failure/Error: TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
         Failed to open TCP connection to localhost:9515 (Cannot assign requested address - connect(2) for "localhost" port 9515)
 ```
 
-This means that Capybara cannot connect to the chromedriver running on your machine from the docker container it is running from. Check to ensure you have ran the commands above with the proper arguments. They are all necessary to allow Capybara and Chromedriver to communicate with each other. If you are still having trouble, it may be your running docker containers are configured incorrectly to communicate with Chromedriver. In this case, you may find it helpful to rebuild your docker containers.
+This means that Capybara cannot connect to the ChromeDriver running on your machine from the docker container it is running from. Check to ensure you have ran the commands above with the proper arguments. They are all necessary to allow Capybara and Chromedriver to communicate with each other. If you are still having trouble, it may be your running docker containers are configured incorrectly to communicate with Chromedriver. In this case, you may find it helpful to rebuild your docker containers.
 
 ### General Tips
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -294,7 +294,7 @@ describe Action do
 end
 ```
 
-Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe actions that can be performed via the UI. 
+Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe actions that can be performed via the UI.
 
 ### Running System Tests
 
@@ -304,9 +304,9 @@ System tests require extra setup steps in order for you to run them locally. As 
 
 2. Download chromedriver
 
-3. Start a bash shell within the Docker Rails environment. Ensure to expose port 3434 by running `docker-compose run -p 3434:3434 --rm rails bash`. Currently, port 3434 is the port with which Capybara will use to serve the test MarkUs instance. 
+3. Start a bash shell within the Docker Rails environment. Ensure to expose port 3434 by running `docker-compose run -p 3434:3434 --rm rails bash`. Currently, port 3434 is the port with which Capybara will use to serve the test MarkUs instance.
 
-4. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ ENABLE_UI_TESTING=true rspec spec/system/` in the bash shell you created in step 3. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. The environment variable setting `ENABLE_UI_TESTING=true` is used to indicate that you have performed all the necessary setup steps and wish to run system tests. 
+4. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ ENABLE_UI_TESTING=true rspec spec/system/` in the bash shell you created in step 3. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. The environment variable setting `ENABLE_UI_TESTING=true` is used to indicate that you have performed all the necessary setup steps and wish to run system tests.
 
     **OPTIONAL**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can set the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -310,7 +310,7 @@ System tests require extra setup steps in order for you to run them locally. As 
 
 3. In a terminal on your machine, run ChromeDriver by typing the command `chromedriver --whitelisted-ips`. The `--whitelisted-ips` flag is used to let ChromeDriver know to allow the connection with a docker terminal.
 
-> :spiral_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
+  > :spiral_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
 
 4. In a separate terminal, start a bash shell within the Docker Rails environment by running `docker-compose run -p 3434:3434 --rm rails bash`. Notice that we exposed port 3434 by adding the argument `-p 3434:3434`. Port 3434 is the port with which Capybara will use to serve the test MarkUs instance for Chrome to use.
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -8,6 +8,7 @@
     - [Helper Gems](#helper-gems)
     - [Model Specifications](#model-specifications)
     - [Controller Specifications](#controller-specifications)
+    - [System Specifications](#system-specifications)
     - [General Tips](#general-tips)
 - [Testing with Jest](#testing-with-jest)
     - [How to Run Jest Specifications](#how-to-run-jest-specifications)
@@ -276,6 +277,38 @@ All Model methods called within the controller should be mocked. This is a test 
 expect(assignment).to receive(:add_group).with(nil).and_return(grouping)
 get :new, assignment_id: assignment
 ```
+
+## System Specifications
+
+System specifications will have the following template:
+
+```ruby
+describe Action do
+  context 'some type of user' do
+    action_examples
+  end
+
+  context 'some other type of user' do
+    action_examples
+  end
+end
+```
+
+Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe actions that can be performed via the UI. 
+
+### Running System Tests
+
+System tests require extra setup steps in order for you to run them locally. As a result, they are disabled by default. If you wish to run and system tests on your machine you will need to perform the following steps:
+
+1. Download Chrome on your machine
+
+2. Download chromedriver
+
+3. Start a bash shell within the Docker Rails environment. Ensure to expose port 3434 by running `docker-compose run -p 3434:3434 --rm rails bash`. Currently, port 3434 is the port with which Capybara will use to serve the test MarkUs instance. 
+
+4. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ ENABLE_UI_TESTING=true rspec spec/system/` in the bash shell you created in step 3. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. The environment variable setting `ENABLE_UI_TESTING=true` is used to indicate that you have performed all the necessary setup steps and wish to run system tests. 
+
+    **OPTIONAL**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can set the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
 
 ### General Tips
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -294,23 +294,43 @@ describe Action do
 end
 ```
 
-Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe actions that can be performed via the UI.
+Notice that the template is similar to controller specifications. `some type of user` and `some other type of user` still generally describe context blocks that correspond to someone who has authorization to perform certain actions. The difference however, is that system tests are used to describe actions performed via the UI.
+
+### Writing System Tests
+
+System tests are written using the Capybara Design Specification Language. 
 
 ### Running System Tests
 
 System tests require extra setup steps in order for you to run them locally. As a result, they are disabled by default. If you wish to run and system tests on your machine you will need to perform the following steps:
 
-1. Download Chrome on your machine
+1. Download Chrome on your machine. This is the browser with which we will use to test UI actions.
 
-2. Download chromedriver
+2. Download ChromeDriver. This will allow our System Tests to perform actions on the Chrome browser.
 
-3. Start a bash shell within the Docker Rails environment. Ensure to expose port 3434 by running `docker-compose run -p 3434:3434 --rm rails bash`. Currently, port 3434 is the port with which Capybara will use to serve the test MarkUs instance.
+3. In a terminal on your machine, run ChromeDriver by typing the command `chromedriver --whitelisted-ips`. The `--whitelisted-ips` flag is used to let ChromeDriver know to allow the connection with a docker terminal.
 
-4. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ ENABLE_UI_TESTING=true rspec spec/system/` in the bash shell you created in step 3. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. The environment variable setting `ENABLE_UI_TESTING=true` is used to indicate that you have performed all the necessary setup steps and wish to run system tests.
+    On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
 
-    **OPTIONAL**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can set the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
+4. In a separate terminal, start a bash shell within the Docker Rails environment by running `docker-compose run -p 3434:3434 --rm rails bash`. Notice that we exposed port 3434 by adding the argument `-p 3434:3434`. Port 3434 is the port with which Capybara will use to serve the test MarkUs instance for Chrome to use.
 
-### General Tips
+5. Run system tests by running `RAILS_RELATIVE_URL_ROOT=/ rspec spec/system` in the bash shell you created in step 4. Currently, Capybara does not support applications with a different relative url root which is why you must set `RAILS_RELATIVE_URL_ROOT=/`. You will also notice that due to the additional setup, by default system tests are ignored and must be explicitly defined in order for rspec to run them. Simply running `RAILS_RELATIVE_URL_ROOT=/ rspec` will not run the tests.
+
+    **Optional**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can set and add the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
+
+**Troubleshooting**
+
+- If you see a test failing with the following message near the top:
+```bash
+Failure/Error: TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
+
+      Errno::EADDRNOTAVAIL:
+        Failed to open TCP connection to localhost:9515 (Cannot assign requested address - connect(2) for "localhost" port 9515)
+```
+
+This means that Capybara cannot connect to the chromedriver running on your machine from the docker container it is running from. Check to ensure you have ran the commands above with the proper arguments. They are all necessary to allow Capybara and Chromedriver to communicate with each other. If you are still having trouble, it may be your running docker containers are configured incorrectly to communicate with Chromedriver. In this case, you may find it helpful to rebuild your docker containers.
+
+## General Tips
 
 #### Code Duplication
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -298,7 +298,7 @@ Notice that the template is similar to controller specifications. `some type of 
 
 ### Writing System Tests
 
-System tests are written using the Capybara Design Specification Language. 
+System tests are written using the Capybara Design Specification Language. These tests revolve around 
 
 ### Running System Tests
 
@@ -318,7 +318,7 @@ System tests require extra setup steps in order for you to run them locally. As 
 
     **Optional**: By default system UI tests are run headless and cannot be viewed using a browser window. While this is generally faster, if you wish to view the tests in a browser window (such as for debugging tests), you can set and add the environment variable `DISABLE_HEADLESS_UI_TESTING=true` when running system tests.
 
-**Troubleshooting**
+#### Troubleshooting
 
 - If you see a test failing with the following message near the top:
 ```bash
@@ -330,7 +330,7 @@ Failure/Error: TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
 
 This means that Capybara cannot connect to the chromedriver running on your machine from the docker container it is running from. Check to ensure you have ran the commands above with the proper arguments. They are all necessary to allow Capybara and Chromedriver to communicate with each other. If you are still having trouble, it may be your running docker containers are configured incorrectly to communicate with Chromedriver. In this case, you may find it helpful to rebuild your docker containers.
 
-## General Tips
+### General Tips
 
 #### Code Duplication
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -309,6 +309,7 @@ System tests require extra setup steps in order for you to run them locally. As 
 2. Download ChromeDriver. This will allow our System Tests to perform actions on the Chrome browser.
 
 3. In a terminal on your machine, run ChromeDriver by typing the command `chromedriver --whitelisted-ips`. The `--whitelisted-ips` flag is used to let ChromeDriver know to allow the connection with a docker terminal.
+
 > :spiral_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
 
 4. In a separate terminal, start a bash shell within the Docker Rails environment by running `docker-compose run -p 3434:3434 --rm rails bash`. Notice that we exposed port 3434 by adding the argument `-p 3434:3434`. Port 3434 is the port with which Capybara will use to serve the test MarkUs instance for Chrome to use.

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -310,7 +310,7 @@ System tests require extra setup steps in order for you to run them locally. As 
 
 3. In a terminal on your machine, run ChromeDriver by typing the command `chromedriver --whitelisted-ips`. The `--whitelisted-ips` flag is used to let ChromeDriver know to allow the connection with a docker terminal.
 
-  > :spiral_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
+    > :spiral_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
 
 4. In a separate terminal, start a bash shell within the Docker Rails environment by running `docker-compose run -p 3434:3434 --rm rails bash`. Notice that we exposed port 3434 by adding the argument `-p 3434:3434`. Port 3434 is the port with which Capybara will use to serve the test MarkUs instance for Chrome to use.
 

--- a/Developer-Guide--Writing-Tests.md
+++ b/Developer-Guide--Writing-Tests.md
@@ -309,7 +309,7 @@ System tests require extra setup steps in order for you to run them locally. As 
 2. Download ChromeDriver. This will allow our System Tests to perform actions on the Chrome browser.
 
 3. In a terminal on your machine, run ChromeDriver by typing the command `chromedriver --whitelisted-ips`. The `--whitelisted-ips` flag is used to let ChromeDriver know to allow the connection with a docker terminal.
-> :spirl_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
+> :spiral_notepad: **Note:** On Windows ensure ChromeDriver is run from a Command Prompt or Windows Powershell.
 
 4. In a separate terminal, start a bash shell within the Docker Rails environment by running `docker-compose run -p 3434:3434 --rm rails bash`. Notice that we exposed port 3434 by adding the argument `-p 3434:3434`. Port 3434 is the port with which Capybara will use to serve the test MarkUs instance for Chrome to use.
 


### PR DESCRIPTION
## Motivation
As part of pull request [#6012](https://github.com/MarkUsProject/Markus/pull/6012) the Capybara gem was added in order to enable testing of the UI. This pull request aims to document what this new type of testing does as well as how to configure and run capybara tests

## Changes
- Added section in Writing Tests page for System Tests
- Described what systems tests are
- Described what Capybara is and added links to learn how to write Capybara System tests
- Described process of setting up System tests to work on MarkUs along with troubleshooting help