### PR TITLE
Add documentation for new student submission API route

### DIFF
--- a/RESTful-API.md
+++ b/RESTful-API.md
@@ -903,6 +903,20 @@ NOTE: the filename string can include a nested path if the file should be added 
 
 NOTE: not all parent directories need to exist in order to create a nested file. For example, if "filename=some/nested/dir/submission.txt"  and "some/" doesn't exist yet, then "some/", "some/nested", and "some/nested/dir" will all be created as well.
 
+### POST /api/courses/:course_id/assignments/:assignment_id/submission_files/submit_file
+
+- description: Submit a file in the currently authenticated user's groups repository for the given assignment. If the user has no group and does not have any pending group requests, this also creates a group for the user. 
+- required parameters:
+    - filename (string)
+    - mime_type (string)
+    - file_content (string or binary data)
+
+NOTE: This route is for STUDENT USE ONLY. 
+
+NOTE: the filename string can include a nested path if the file should be added in a subfolder (ex: "filename=some/nested/dir/submission.txt")
+
+NOTE: not all parent directories need to exist in order to create a nested file. For example, if "filename=some/nested/dir/submission.txt"  and "some/" doesn't exist yet, then "some/", "some/nested", and "some/nested/dir" will all be created as well.
+
 ### GET /api/courses/:course_id/assignments/:assignment_id/groups/:group_id/submission_files
 
 - description: Download a zip archive containing submission files submitted by the given group for the given assignment **or** the content of a single file


### PR DESCRIPTION
## Context
As part of pull request [#6057](https://github.com/MarkUsProject/Markus/pull/6057), a new route was added to allow students to submit files via the API. This aims to add the documentation for this new API route

## Changes
- Added new POST description of new API `submit_file` route