### PR TITLE
Note that LTI features are not enabled by default

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -259,6 +259,8 @@ This feature informs you of all uncaught exceptions that occur in the MarkUs bac
 
 ## LTI Settings
 
+>**Note**: LTI routes are not enabled in production by default. To enable them, you must edit `routes.rb` file.
+
 If you wish to use Learning Tools Interoperability (LTI) with Markus, you'll need to configure the LTI settings as follows
 
 - `lti.domains` must be a whitelist of all hosts you expect to receive LTI launches from.

--- a/Learning-Tools-Interoperability.md
+++ b/Learning-Tools-Interoperability.md
@@ -1,5 +1,7 @@
 # Learning Tools Interoperability (LTI)
 
+>**Note**: LTI functionality is not enabled by default, and must be enabled by a system administrator.
+
 MarkUs integrates with other Learning Management Systems (LMS) via the [LTI 1.3 standard](https://www.imsglobal.org/spec/lti/v1p3).
 Currently, MarkUs supports the following LMS platforms:
 


### PR DESCRIPTION
Adds a note to the LTI page that LTI is not enabled by default, as well as a note on configuration about how to enable it.