### PR TITLE
Rest-API documentation for Assignment #destroy.

### DIFF
--- a/RESTful-API.md
+++ b/RESTful-API.md
@@ -661,8 +661,8 @@ NOTE: the "AdminRole" type can only be used by AdminUser users
 
 - description: Delete the assignment corresponding to the given course and assignment id's, if it has no groups.
 - required parameters:
-  - id (integer)
-  - course_id (integer)
+    - id (integer)
+    - course_id (integer)
 
 NOTE: this is only available to authorised instructors (or admins)
 

--- a/RESTful-API.md
+++ b/RESTful-API.md
@@ -657,6 +657,15 @@ NOTE: the "AdminRole" type can only be used by AdminUser users
     - has_peer_review (boolean)
     - starter_file_type (one of "simple", "sections", "shuffle", "group")
 
+### DELETE /api/courses/:course_id/assignments/:id
+
+- description: Delete the assignment corresponding to the given course and assignment id's, if it has no groups.
+- required parameters:
+  - id (integer)
+  - course_id (integer)
+
+NOTE: this is only available to authorised instructors (or admins)
+
 ### GET /api/courses/:course_id/assignments/:id/test_files
 
 - description: Download a zip file containing all autotesting test files for this assignment


### PR DESCRIPTION
One new entry to the `RESTful-API.md` file (following the format of existing entries) to document the new `#destroy` action of `controllers/api/assignments_controller`.

- Destroying an assignment --> `DELETE /api/courses/:course_id/assignments/:id`