### PR TITLE
Update Docker setup instructions

### DIFF
--- a/Developer-Guide--Set-Up-With-Docker.md
+++ b/Developer-Guide--Set-Up-With-Docker.md
@@ -307,8 +307,8 @@ I'm seeing a test failing with the following message near the top:
 Run the following commands:
 
 ```console
-$ docker compose run --rm rails bash  # This takes you into the Docker container
-$ ./venv/bin/python3 -m pip install -r requirements-jupyter.txt
+docker compose run --rm rails bash  # This takes you into the Docker container
+./venv/bin/python3 -m pip install -r requirements-jupyter.txt
 ```
 
 Then try re-running the tests. You can do this from your current terminal (inside the Docker container) simply by running `rspec`.

--- a/Developer-Guide--Set-Up-With-Docker.md
+++ b/Developer-Guide--Set-Up-With-Docker.md
@@ -1,93 +1,93 @@
 # Developer Guide: Set Up with Docker
 
-## Downloading and Installing
-
 If you want to get started on working on MarkUs quickly and painlessly, this is the way to do it.
+
+## Downloading and Installing
 
 1. If you are using **Windows**, you will need to install Windows Subsystem for Linux (WSL) by following the instructions on [this page](https://docs.microsoft.com/en-us/windows/wsl/install-win10). (The "Simplified Installation" section is probably easiest, but you need to join the Windows Insiders Program with a Microsoft account.)
 
-    - If you are given a choice of what operating system to use, select *Ubuntu 20.04*.
+    - If you are given a choice of which operating system to use, select *Ubuntu 22.04*.
 
-2. Install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/).
+2. Install [Docker](https://docs.docker.com/get-docker/).
 
     - On Windows, make sure you've selected the "WSL 2 backend" tab under "System Requirements" and follow those instructions.
     - On Linux, also follow the instructions on "Manage Docker as a non-root user" [here](https://docs.docker.com/install/linux/linux-postinstall/).
 
 3. If you are using **Windows**, you'll need to open a terminal into the WSL system you installed. *This is the terminal where you'll type in the rest of the commands in this section.*
 
-    1. To start the WSL terminal, open the start menu and type in "ubuntu". Click on the "Ubuntu 20.04" application. (We recommend pinning this to your taskbar to make it easier to find in the future.)
+    1. To start the WSL terminal, open the start menu and type in "ubuntu". Click on the "Ubuntu 22.04" application. (We recommend pinning this to your taskbar to make it easier to find in the future.)
     2. Type in the command `pwd`, which shows what folder you're currently in. You should see `/home/<your user name>` printed. If it isn't, switch to your home directory using the command `cd ~`.
 
-4. Clone the Markus repository from GitHub by following the instructions in [Setting up Git and MarkUs](Developer-Guide--Setting-up-Git.md). (This is a document you will want to read very carefully and may come back to.)
+4. Clone the Markus repository.
 
 5. Change into the repository that you just cloned: `cd Markus`.
 
-6. Run `docker compose build app`.
+6. If you are on **Windows (WSL)** or **Linux**, you will need to configure Docker to make sure the application files are owned by a user with the same UID on your host machine as in the containers:
 
-    1. On Linux running docker engine (not docker desktop): you will need to make sure that the files are owned by a user with the same UID on your host machine as in the container:
-        - Create a file named `docker-compose.override.yml` in the root directory of the MarkUs code (should be your current directory)
-        - Discover your current UID by running the `id -u` command
-        - Write the following to the newly created `docker-compose.override.yml` file (replace 1001 with the UID that you discovered in the previous step):
+    1. Run the command `id -u`. If the output is `1001` you can skip this the rest of this step and move onto Step 7 below. Otherwise, keep going.
+    2. Follow the first two steps in the [Installing and Configuring RubyMine](#installing-and-configuring-rubymine) section below to open the MarkUs repository in RubyMine.
+    3. In the MarkUs repository, create a new top-level file named `compose.override.yaml`.
+    4. Copy and paste the following text into the `compose.override.yaml` file, replacing `<UID>` with the number returned by `id -u` earlier.
 
-            ```yml
-            services:
-              app:
+        ```yml
+        services:
+            app:
                 build:
-                  args:
-                    UID: 1001
-            ```
+                    args:
+                        UID: 1000
+            rails:
+                build:
+                    args:
+                        UID: 1000
+            ssh:
+                build:
+                    args:
+                        UID: 1000
+            resque:
+                build:
+                    args:
+                        UID: 1000
+            resque-scheduler:
+                build:
+                    args:
+                        UID: 1000
+            webpack:
+                build:
+                    args:
+                        UID: 1000
+        ```
 
-        - now you can run `docker compose build app`
+7. Run `docker compose build app`.
 
-7. Run `docker compose up rails`. The first time you run this it will take a long time because it'll install all of MarkUs' dependencies, and then seed the MarkUs application with sample data before actually running the server. When the server actually starts, you'll see some terminal output that looks like:
+8. Run `docker compose up rails`. The first time you run this it will take a long time because it'll install all of MarkUs' dependencies, and then seed the MarkUs application with sample data before actually running the server. When the server actually starts, you'll see some terminal output that looks like:
 
     ```text
-    Puma starting in cluster mode...
-    * Version 4.3.1 (ruby 2.5.3-p105), codename: Mysterious Traveller
-    * Min threads: 0, max threads: 16
-    * Environment: development
-    * Process workers: 3
-    * Preloading application
-    * Listening on tcp://0.0.0.0:3000
-    Use Ctrl-C to stop
-    - Worker 0 (pid: 185) booted, phase: 0
-    - Worker 1 (pid: 193) booted, phase: 0
-    - Worker 2 (pid: 201) booted, phase: 0
+    => Booting Puma
+    => Rails 7.1.3.2 application starting in development
+    => Run `bin/rails server --help` for more startup options
+    [1] Puma starting in cluster mode...
+    [1] * Puma version: 6.4.2 (ruby 3.0.2-p107) ("The Eagle of Durango")
+    [1] *  Min threads: 0
+    [1] *  Max threads: 5
+    [1] *  Environment: development
+    [1] *   Master PID: 1
+    [1] *      Workers: 3
+    [1] *     Restarts: (✔) hot (✖) phased
+    [1] * Preloading application
+    [1] * Listening on http://0.0.0.0:3000
+    [1] Use Ctrl-C to stop
+    [1] - Worker 0 (PID: 71) booted in 0.01s, phase: 0
+    [1] - Worker 1 (PID: 75) booted in 0.01s, phase: 0
+    [1] - Worker 2 (PID: 77) booted in 0.01s, phase: 0
     ```
 
-    1. On **Windows**, open a separate WSL terminal (but leave the current one running), and type in the command `docker compose run --rm rails bash`. This will take you into the Docker container; you'll see the prompt change to `app/$`.
-
-    2. Run the command `rails js:routes`, which will take a moment to generate a required file.
-
-8. Open your web browser and type in the URL `localhost:3000/csc108`. The initial page load might be slow, but eventually you should see a login page. Use the username `instructor` and any non-empty password to login.
+9. Open your web browser and type in the URL `localhost:3000/csc108`. The initial page load might be slow, but eventually you should see a login page. Use the username `instructor` and any non-empty password to login.
 
     *Tip*: to terminate the Rails server, go to the terminal window where the server is running and press `Ctrl + C`/`⌘ + C`.
 
     - On Windows Home Edition, you'll need to use the Docker container's IP address instead: `192.168.99.100:3000/csc108`.
 
-9. In a new terminal window, go into the Markus directory again and run `docker compose run rails rspec` to run the MarkUs test suite. This will take several minutes to run, but all tests should pass.
-
-    **Troubleshooting**
-
-    - If you see a test failing with the following message near the top:
-
-        ```text
-        1) SubmissionsController#get_file When the file is a jupyter notebook file should download the file as is
-           Failure/Error: _stdout, stderr, status = Open3.capture3(*args, stdin_data: file_contents)
-
-           Errno::ENOENT:
-               No such file or directory - /app/nbconvertvenv/bin/jupyter-nbconvert
-        ```
-
-    Run the following commands:
-
-    ```console
-    docker compose run --rm rails bash  # This takes you into the Docker container
-    python3.8 -m venv /app/nbconvertvenv
-    /app/nbconvertvenv/bin/pip install wheel nbconvert
-    ```
-
-    Then try re-running the tests. You can do this from your current terminal (inside the Docker container) simply by running `rspec`.
+10. In a new terminal window, go into the Markus directory again and run `docker compose run --rm rails rspec` to run the MarkUs test suite. This will take several minutes to run, but all tests should pass.
 
 Hooray! You have MarkUs up and running. Please keep reading for our recommended developer setup.
 
@@ -99,7 +99,7 @@ We strongly recommend RubyMine (a JetBrains IDE) for all MarkUs development.
 
 2. Open the MarkUs repository in RubyMine.
 
-    - On Windows, your repository will be located at `\\wsl$\Ubuntu-20.04\home\<your user name>\Markus`.
+    - On Windows, your repository will be located at `\\wsl$\Ubuntu-22.04\home\<your user name>\Markus`.
 
 3. Complete the setup steps under [Docker: Enable Docker Support JetBrains guide](https://www.jetbrains.com/help/ruby/docker.html#enable_docker).
 
@@ -117,7 +117,7 @@ We strongly recommend RubyMine (a JetBrains IDE) for all MarkUs development.
 
 ## Installing Pre-Commit Hooks
 
-We use [pre-commit](https://pre-commit.com/) to run automated checks on code before each commit. To set this up on your local computer (not in Docker):
+We use [pre-commit](https://pre-commit.com/) to run automated checks on code before each commit. To set this up on your local computer (*not* in a Docker container):
 
 1. First, install Python 3.
 2. Then, install the pre-commit library: `$ python3 -m pip install pre-commit` (or just `python` instead of `python3`, depending on your Python executable.
@@ -133,11 +133,11 @@ After this, these checks will run every time you make a commit. If all checks pa
 Here's a summary of the few most common tasks you'll use in your development.
 
 - Start the MarkUs server: `docker compose up --no-recreate rails`
-- Run the MarkUs rspec test suite: `docker compose run rails rspec`
-- Run a specific rspec test file: `docker compose run rails rspec FILE`
-- Run the Markus Jest test suite:  `docker compose run rails npm run test`
-- Run the Markus Jest test suite with the test coverage shown:  `docker compose run rails npm run test-cov`
-- Run a specific Jest test file: `docker compose run rails npm run test FILE`
+- Run the MarkUs rspec test suite: `docker compose run --rm rails rspec`
+- Run a specific rspec test file: `docker compose run  --rm rails rspec FILE`
+- Run the Markus Jest test suite:  `docker compose run  --rm rails npm run test`
+- Run the Markus Jest test suite with the test coverage shown:  `docker compose run --rm rails npm run test-cov`
+- Run a specific Jest test file: `docker compose run  --rm rails npm run test FILE`
 - Start a shell within the Docker Rails environment: `docker compose run --rm rails bash`.
   Within this shell, you can:
     - Install new dependencies: `bundle install`, `npm ci`
@@ -197,7 +197,7 @@ If the `rails db:autotest_run` fails, you can still run the tests manually in yo
 
 ## Setting up ActionMailer
 
-If you plan on doing work that involves sending/recieving emails from MarkUs, you will need to [configure ActionMailer](https://guides.rubyonrails.org/action_mailer_basics.html). To get you started quickly on setting up ActionMailer and understanding what it is used for in MarkUs, follow the instructions outlined in [Enabling ActionMailer In Development](Developer-Guide--Tips-And-Tricks--Enabling-ActionMailer-In-Development.md).
+If you plan on doing work that involves sending/receiving emails from MarkUs, you will need to [configure ActionMailer](https://guides.rubyonrails.org/action_mailer_basics.html). To get you started quickly on setting up ActionMailer and understanding what it is used for in MarkUs, follow the instructions outlined in [Enabling ActionMailer In Development](Developer-Guide--Tips-And-Tricks--Enabling-ActionMailer-In-Development.md).
 
 ## Troubleshooting
 
@@ -208,8 +208,8 @@ If you plan on doing work that involves sending/recieving emails from MarkUs, yo
 I'm writing frontend code. The files I've changed should according to the Webpack config files trigger Webpack rebuild, but that's not happening. I've verified that
 
 1. My changes are valid and should be displayed from the URL I'm accessing.
-2. There are no errors in the Webpacker container's logs.
-3. If I run `npm run build-dev` in the Webpacker container's console directly, it succeeds and I'm able to see my changes afterwards.
+2. There are no errors in the webpack container's logs.
+3. If I run `npm run build-dev` in the webpack container's console directly, it succeeds and I'm able to see my changes afterwards.
 
 ### A1
 
@@ -220,11 +220,11 @@ I'm writing frontend code. The files I've changed should according to the Webpac
 When I run `docker compose up rails`, or when I restart my previously created `rails` container, I get a warning/error along the lines of
 
 ```MARKDOWN
-markus-rails-1  | system temporary path is world-writable: /tmp
-markus-rails-1  | /tmp is world-writable: /tmp
-markus-rails-1  | . is not writable: /app
-markus-rails-1  | Exiting
-markus-rails-1  | /usr/lib/ruby/3.0.0/tmpdir.rb:39:in `tmpdir': could not find a temporary directory (ArgumentError)
+markus-     system temporary path is world-writable: /tmp
+markus-     /tmp is world-writable: /tmp
+markus-     . is not writable: /app
+markus-     Exiting
+markus-     /usr/lib/ruby/3.0.0/tmpdir.rb:39:in `tmpdir': could not find a temporary directory (ArgumentError)
 [...stacktrace]
 ```
 
@@ -232,26 +232,24 @@ after following the setup guide step by step. I've looked into my host setup and
 
 ### A2
 
-It's unclear exactly why or how this occured, but one fix is as simple as using another directory for this purpose. Ruby reads a variety of environment variables (env vars) to determine the system's temporary directory that it can use, and you can customize that directory with an env var. Both warnings/errors are complaining about the same thing: no available `TMPDIR`.
+It's unclear exactly why or how this occurred, but one fix is as simple as using another directory for this purpose. Ruby reads a variety of environment variables (env vars) to determine the system's temporary directory that it can use, and you can customize that directory with an env var. Both warnings/errors are complaining about the same thing: no available `TMPDIR`.
 
 Since this is not a wide-spread issue, it's more reasonable to have the setup living entirely on your local (i.e. ignored by git) than committing it to the repo.
 
-1. Start by creating a `docker-compose.override.yml` file under Markus root. Notice that the filename is already listed in `.gitignore`.
+1. Start by creating a `compose.override.yaml` file under Markus root. Notice that the filename is already listed in `.gitignore`.
 2. The general idea is simple - configure `TMPDIR`, then pass this configuration in. Now we need to find a potential `TMPDIR` candidate inside the container. Reading <https://github.com/ruby/ruby/blob/ruby_3_0/lib/tmpdir.rb> gives us an idea of what ruby expects (at the time of writing, Markus was in ruby 3.0, but this file shouldn't expect major changes in the future versions. If it starts using other env var(s), update this documentation to reflect the new env var(s)).
 3. You can find a directory in the rails container with the correct permissions (1777) & that is unused by Markus, or create your own. In my case `/var/tmp` fit the profile.
     1. I found the directory by starting a shell in the `rails` container with `docker exec -it` and then running `find -type d -perm 1777`
-4. Write this env var into the `docker-compose.override.yml` file you created. For example:
+4. Write this env var into the `compose.override.yaml` file you created. For example:
 
     ```YAML
-    version: '3.7'
-
     services:
-    rails:
-        environment:
-        - TMPDIR=/var/tmp
+        rails:
+            environment:
+            - TMPDIR=/var/tmp
     ```
 
-5. Save your changes. After `docker compose build app`, make sure you run `docker compose -f docker-compose.override.yml docker-compose.yml up rails` instead of just `docker compose up rails`. This will apply the `TMPDIR` we created, which would resolve the issue.
+5. Save your changes. After `docker compose build app`, make sure you run `docker compose -f compose.override.yaml compose.yaml up rails` instead of just `docker compose up rails`. This will apply the `TMPDIR` we created, which would resolve the issue.
 
 ### Q3
 
@@ -291,3 +289,26 @@ Again, it's unclear exactly why this happened, but there's a fix.
 4. Once `rails` container is up, start a shell inside it and run `bundle exec rails db:prepare`. Without running this, you won't be able to browse markus UI.
     1. If for whatever reason this command fails, try `rails db:drop && rails db:create && rails db:migrate && rails db:seed` instead.
 5. The downside is you'll have to redo this process every time the containers are recreated, but otherwise this should resolve the issue. Verify that the `schema_migrations` tables now contain the correct number of migration records.
+
+### Q4
+
+I'm seeing a test failing with the following message near the top:
+
+```text
+1) SubmissionsController#get_file When the file is a jupyter notebook file should download the file as is
+   Failure/Error: _stdout, stderr, status = Open3.capture3(*args, stdin_data: file_contents)
+
+   Errno::ENOENT:
+       No such file or directory - /app/nbconvertvenv/bin/jupyter-nbconvert
+```
+
+### A4
+
+Run the following commands:
+
+```console
+$ docker compose run --rm rails bash  # This takes you into the Docker container
+$ ./venv/bin/python3 -m pip install -r requirements-jupyter.txt
+```
+
+Then try re-running the tests. You can do this from your current terminal (inside the Docker container) simply by running `rspec`.

--- a/Developer-Guide--Set-Up-With-Docker.md
+++ b/Developer-Guide--Set-Up-With-Docker.md
@@ -34,27 +34,27 @@ If you want to get started on working on MarkUs quickly and painlessly, this is 
             app:
                 build:
                     args:
-                        UID: 1000
+                        UID: <UID>
             rails:
                 build:
                     args:
-                        UID: 1000
+                        UID: <UID>
             ssh:
                 build:
                     args:
-                        UID: 1000
+                        UID: <UID>
             resque:
                 build:
                     args:
-                        UID: 1000
+                        UID: <UID>
             resque-scheduler:
                 build:
                     args:
-                        UID: 1000
+                        UID: <UID>
             webpack:
                 build:
                     args:
-                        UID: 1000
+                        UID: <UID>
         ```
 
 7. Run `docker compose build app`.
@@ -220,11 +220,11 @@ I'm writing frontend code. The files I've changed should according to the Webpac
 When I run `docker compose up rails`, or when I restart my previously created `rails` container, I get a warning/error along the lines of
 
 ```MARKDOWN
-markus-     system temporary path is world-writable: /tmp
-markus-     /tmp is world-writable: /tmp
-markus-     . is not writable: /app
-markus-     Exiting
-markus-     /usr/lib/ruby/3.0.0/tmpdir.rb:39:in `tmpdir': could not find a temporary directory (ArgumentError)
+system temporary path is world-writable: /tmp
+/tmp is world-writable: /tmp
+. is not writable: /app
+Exiting
+/usr/lib/ruby/3.0.0/tmpdir.rb:39:in `tmpdir': could not find a temporary directory (ArgumentError)
 [...stacktrace]
 ```
 


### PR DESCRIPTION
1. Make clear that the `compose.override.yml` UID setting needs to be done for both Linux and WSL developers.
2. Move one test troubleshooting tip to the Troubleshooting section.
3. Add `--rm` flag to all `docker compose run` commands.
4. Minor grammatical and wording changes.