### PR TITLE
Fix docker guide to build all images instead of just app

### DIFF
--- a/Developer-Guide--Set-Up-With-Docker.md
+++ b/Developer-Guide--Set-Up-With-Docker.md
@@ -57,7 +57,7 @@ If you want to get started on working on MarkUs quickly and painlessly, this is 
                         UID: <UID>
         ```
 
-7. Run `docker compose build app`.
+7. Run `docker compose build`.
 
 8. Run `docker compose up rails`. The first time you run this it will take a long time because it'll install all of MarkUs' dependencies, and then seed the MarkUs application with sample data before actually running the server. When the server actually starts, you'll see some terminal output that looks like:
 


### PR DESCRIPTION
Currently, the guide directs a reader to run `docker compose build app`, which only builds the `markus-dev` image for the `app` service. This worked well for previous versions of the `compose.yml` file in the main project because there were no other images to build. However, under the changes introduced in https://github.com/MarkUsProject/Markus/pull/7037, each service (except `postgres` and `redis`, which pull from official images) has its own dedicated "MarkUs image", and therefore would have to be built as well.

So, this PR proposes changing `docker compose build app` to `docker compose build` to build the required images. From what I can tell, if this is not done, Docker attempts to pull from Docker Hub, which (for obvious reasons) fails.