### PR TITLE
add remote validation setting

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -223,7 +223,7 @@ local_auth_login_name: shibboleth
 
 Additionally, MarkUs can be set to restrict remote logins based on username and/or IP when using remote authentication.
 
-**To enable restricted remote authentication, set the following settings:**
+**To enable restricted remote authentication, set the following setting:**
 
 - `remote_validate_file:` an absolute path to a script that expects input from stdin (user name, password (blank), and IP address; separated by "\n") and returns 0 if the user is authenticated and any other positive integer otherwise.
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -81,6 +81,7 @@ queues:
 redis:
   url: # url of a running redis database
 validate_file: # (See "User Authentication Options" below)
+remote_validate_file: # (See "User Authentication Options" below)
 validate_ip: # (See "User Authentication Options" below)
 validate_custom_status_message: # (See "User Authentication Options" below)
 validate_user_not_allowed_message: # (See "User Authentication Options" below)
@@ -219,6 +220,12 @@ validate_custom_status_message:
 ```yaml
 local_auth_login_name: shibboleth
 ```
+
+Additionally, MarkUs can be set to restrict remote logins based on username and/or IP when using remote authentication.
+
+**To enable restricted remote authentication, set the following settings:**
+
+- `remote_validate_file:` an absolute path to a script that expects input from stdin (user name, password (blank), and IP address; separated by "\n") and returns 0 if the user is authenticated and any other positive integer otherwise.
 
 ### Logout redirect
 


### PR DESCRIPTION
Adds a description of the `remote-validate_file` option for exam mode markus