### PR TITLE
Mention size limitation on feedback files

### DIFF
--- a/Instructor-Guide--Assignments--Automated-Testing.md
+++ b/Instructor-Guide--Assignments--Automated-Testing.md
@@ -131,7 +131,7 @@ This section lists all the fields that are common to all testers:
 
     > :warning: **WARNING:** If a test hits the timeout limit, a timeout error will be reported for all tests in this group.
 
-- **Feedback Files:** The name of files that the autotester will send back to MarkUs to display as feedback files associated with the test result. You can specify multiple feedback files by clicking the `+` icon below this section. These files should exist after the tests are run.
+- **Feedback Files:** The name of files that the autotester will send back to MarkUs to display as feedback files associated with the test result. You can specify multiple feedback files by clicking the `+` icon below this section. These files should exist after the tests are run. Each individual file must not exceed 1 GB in size.
 
     Possible use cases include:
 

--- a/RESTful-API.md
+++ b/RESTful-API.md
@@ -1008,6 +1008,8 @@ NOTE: if the filename parameter is given, only the content from a single file wi
 
 NOTE: adding feedback files to subdirectories is currently not supported
 
+NOTE: the size of file_content must not exceed 1 GB.
+
 ### GET /api/courses/:course_id/assignments/:assignment_id/groups/:group_id/feedback_files
 
 - description: Get all feedback file information for a given group for a given assignment


### PR DESCRIPTION
PostgreSQL has a hard size cap of 1 GB for field content. Since feedback files are stored in the fields, their size is subject to this hard limit (despite the TOAST technique.) This change adds mentions of this limitation whenever feedback files are discussed.